### PR TITLE
check api key

### DIFF
--- a/internal/conductorr/services/search/tmdb.go
+++ b/internal/conductorr/services/search/tmdb.go
@@ -282,7 +282,11 @@ func (t *TmdbAPI) SearchByTitle(title, contentType string, page int) (*SearchRes
 		u.Path += "multi"
 	}
 	q := u.Query()
-	q.Set("api_key", settings.TmdbAPIKey)
+	if (settings.TmdbAPIKey == "") {
+		return nil, fmt.Errorf("No API key has been configured")
+	} else {
+		q.Set("api_key", settings.TmdbAPIKey)
+	}
 	q.Set("query", title)
 	q.Set("include_adult", "true")
 	q.Set("page", strconv.Itoa(page))


### PR DESCRIPTION
i think tmdb needs an api key and the endpoint otherwise fails silently returns a 200 right now which can be confusing

```
 conductorr (tony/config-check) ✗ curl "https://api.themoviedb.org/3/search/multi\?include_adult\=true\&page\=1\&query\=happy+feet"
{"status_code":7,"status_message":"Invalid API key: You must be granted a valid key.","success":false}
```