### PR TITLE
only run docker release on main branch

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,5 +1,6 @@
 on:
   push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
i noticed the previous PR failed [this job](https://github.com/lsnow99/conductorr/actions/runs/18067933987/job/51413271995?pr=15) because the tag was invalid (following the existing naming convention)

we could reformat the tag or only run it on the main branch, and i think the latter makes more sense, given the workflow's actually supposed to push to a registry