### PR TITLE
add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ docusite/docs/public/csl.wasm
 **/.pnpm-debug.log
 /test/csl
 docusite/docs/js/wasm_exec.js
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,25 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746904237,
+        "narHash": "sha256-3e+AVBczosP5dCLQmMoMEogM57gmZ2qrVSrmq9aResQ=",
+        "rev": "d89fc19e405cb2d55ce7cc114356846a0ee5e956",
+        "revCount": 797896,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.797896%2Brev-d89fc19e405cb2d55ce7cc114356846a0ee5e956/0196c1a7-7ad3-74a9-9d50-1b854aca6d6c/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "A Nix-flake-based Go 1.22 development environment";
+
+  inputs.nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1";
+
+  outputs = inputs:
+    let
+      goVersion = 23; # Change this to update the whole stack
+
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSupportedSystem = f: inputs.nixpkgs.lib.genAttrs supportedSystems (system: f {
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [ inputs.self.overlays.default ];
+        };
+      });
+    in
+    {
+      overlays.default = final: prev: {
+        nodejs = prev.nodejs_24;
+        go = final."go_1_${toString goVersion}";
+      };
+
+      devShells = forEachSupportedSystem ({ pkgs }: {
+        default = pkgs.mkShell {
+          packages = with pkgs; [
+            # go (version is specified by overlay)
+            go
+
+            # goimports, godoc, etc.
+            gotools
+
+            # https://github.com/golangci/golangci-lint
+            golangci-lint
+            nodejs
+            nodePackages.pnpm
+            brotli
+            just
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
i've personally been using nix flakes in my projects recently and i've been finding a lot of success with it, especially when needing to work with other developers.

If you're not familiar with nix/nix flakes, the caveman's explanation is that this functionally gives us a unified development environment. `flake.nix` specifies packages that should be installed in this project: go, node, pnpm, brotli, just, etc and activating the flake ensures these packages are installed at the right versions

<details><summary>Excerpt from my other projects on how to set it up</summary>
<p>

We use [NixOS](https://nixos.org/) to maintain a consistent development environment.
I recommend using the [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer) to install Nix:
```shell
curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
  sh -s -- install
```

Once installed, `cd` into this directory and activate a development shell with:
```shell
nix develop
```
This gives you access to all of the programs that are needed to manage this repository.

**Further documentation will assume you have ran `nix develop`.**
**Every time you re-open your shell, you have to reactivate the development shell with `nix develop` again.**

If you want to automatically enter the development shell when inside this directory, run...
```shell
curl -sfL https://direnv.net/install.sh | bash
```

...and follow the instructions to update your shell configuration.

</p>
</details> 

as for how nix actually works, there's too much to explain in this PR, but I'd start at [their docs](https://nixos.org/learn/). i'll also be happy to answer questions if you're unsure about this

also, this is a completely opt-in thing, so if you don't want to use this, these files can just be ignored